### PR TITLE
edit gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-tmp*
 __pycache__/
 .ipynb_checkpoints/
 Untitled.ipynb


### PR DESCRIPTION
remove tmp* from gitignore so that automatically generated docs resource files are properly included in the repo