### PR TITLE
Fix the custom memo feature

### DIFF
--- a/src/jtcmake/group_tree/group_mixins/basic.py
+++ b/src/jtcmake/group_tree/group_mixins/basic.py
@@ -87,6 +87,9 @@ class BasicInitMixin(IGroup, metaclass=ABCMeta):
         if memodir is None:
             memo_factory = string_memo_factory
         else:
+            if not os.path.exists(memodir):
+                raise FileNotFoundError(f"memodir ({memodir}) was not found")
+
             memo_factory = CustomDirMemoFactory(Path(memodir))
 
         info = GroupTreeInfo(writer, memo_factory, self)
@@ -274,6 +277,7 @@ class CustomDirMemoFactory:
             string_normalizer,
             string_serializer,
             string_deserializer,
+            extra_info=os.path.abspath(output0),
         )
 
     def __init__(self, memodir: Path) -> None:

--- a/tests/group_tree/test_rule_.py
+++ b/tests/group_tree/test_rule_.py
@@ -245,7 +245,7 @@ def test_Rule_init_parse_deco_func(method, expect):
         rule.Rule_init_parse_deco_func(method) == expect
 
 
-def test_memo_file():
+def test_memo_file(tmp_path: Path):
     def _f(_: Path):
         ...
 
@@ -253,9 +253,9 @@ def test_memo_file():
     r = g.add("a", _f)(rule.SELF)
     assert os.path.abspath(r.memo_file) == os.path.abspath("./.jtcmake/a.json")
 
-    g = UntypedGroup(memodir="./memodir")
+    g = UntypedGroup(memodir=tmp_path)
     r = g.add("a", _f)(rule.SELF)
     basename = hashlib.md5(os.path.abspath(r[0]).encode("utf8")).digest().hex()
     assert os.path.abspath(r.memo_file) == os.path.abspath(
-        f"./memodir/{basename}.json"
+        tmp_path / f"{basename}.json"
     )


### PR DESCRIPTION
- check existence of memodir
- output0's path is now written in the memo file as meta data