### PR TITLE
Add file vs directory path collision detector

### DIFF
--- a/src/jtcmake/group_tree/groups.py
+++ b/src/jtcmake/group_tree/groups.py
@@ -159,7 +159,8 @@ class StaticGroupBase(BasicMixin, BasicInitMixin, SelectorMixin, MemoMixin):
 
             if tp == Rule:
                 # Rule
-                r: Rule[str] = Rule.__new__(Rule)
+                r_: Any = Rule.__new__(Rule)
+                r: Rule[str] = r_
                 r.__init_partial__(fqcname, self._info, None, self)
                 setattr(self, child_name, r)
                 self._rules[child_name] = r

--- a/tests/group_tree/group_mixins/test_selector.py
+++ b/tests/group_tree/group_mixins/test_selector.py
@@ -44,7 +44,7 @@ def test_get_offspring_groups():
 def _create_group_for_test_select():
     """
     a/
-    |-- a (a)
+    |-- a (a.txt)
     |-- b (b1.txt, b2.txt)
     |-- c/
     |-- |-- d/
@@ -59,7 +59,7 @@ def _create_group_for_test_select():
 
     g = UntypedGroup()
 
-    g.add("a", _fn)(SELF)
+    g.add("a", "a.txt", _fn)(SELF)
     g.add("b", ["b1.txt", "b2.txt"], _fn)(SELF[0], SELF[1])
 
     g.add_group("c")
@@ -109,7 +109,7 @@ def test_group_select_files():
     g = _create_group_for_test_select()
 
     # no *
-    assert g.select_files("a/a") == [g.a.a]
+    assert g.select_files("a/a.txt") == [g.a[0]]
 
     # *, **
-    assert g.select_files("**/*.txt") == [g.b[0], g.b[1], g["a/b"].a[0]]
+    assert g.select_files("**/*.txt") == [g.a[0], g.b[0], g.b[1], g["a/b"].a[0]]

--- a/tests/group_tree/test_integration.py
+++ b/tests/group_tree/test_integration.py
@@ -47,3 +47,23 @@ def test_noskip(tmp_path: Path):
     flag = False
     g.make()
     assert flag
+
+
+def test_file_dir_collision():
+    def fn(_: Path):
+        ...
+
+    g = UntypedGroup()
+    g.add("a", fn)(SELF)
+
+    with pytest.raises(Exception):
+        g.add("a/b.txt", fn)(SELF)
+
+    g = UntypedGroup()
+    g.add("a/b.txt", fn)(SELF)
+
+    with pytest.raises(Exception):
+        g.add("a", fn)(SELF)
+
+    g = UntypedGroup()
+    g.add("a", fn)(SELF)


### PR DESCRIPTION
Also fixed some tests whose setting contained a group tree with file vs directory collision.